### PR TITLE
Make GRPO advantage double-normalization configurable

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -53,6 +53,11 @@ actor_rollout_ref:
 
 algorithm:
   adv_estimator: grpo
+  # norm_adv_by_std_in_grpo: divide group-centered scores by group std (Dr.GRPO if False).
+  # grpo_double_normalize: add a second batch-global whitening on top of group-norm;
+  #   True (default) = current ReSkill behavior, False = standard group-norm-only GRPO.
+  norm_adv_by_std_in_grpo: True
+  grpo_double_normalize: True
   use_kl_in_reward: False
   gamma: 1.0
   lam: 1.0

--- a/reskill/reskill_trainer.py
+++ b/reskill/reskill_trainer.py
@@ -1025,10 +1025,16 @@ class ReSkillTrainer(RayPPOTrainer):
 
                             norm_adv_by_std_in_grpo = self.config.algorithm.get(
                                 "norm_adv_by_std_in_grpo", True)
+                            # Default True = double-normalize (group-norm + RF++-baseline-style
+                            # masked_whiten tail), reproducing historical ReSkill runs. Set
+                            # algorithm.grpo_double_normalize=false for standard GRPO (group-norm only).
+                            grpo_double_normalize = self.config.algorithm.get(
+                                "grpo_double_normalize", True)
 
                             batch = compute_trajectory_grpo_advantage(
                                 batch,
                                 norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                                double_normalize=grpo_double_normalize,
                             )
 
                         if self.use_critic:

--- a/reskill/verl_integration/algorithms.py
+++ b/reskill/verl_integration/algorithms.py
@@ -39,6 +39,7 @@ def compute_grpo_outcome_advantage(
     traj_index: np.ndarray,
     epsilon: float = 1e-6,
     norm_adv_by_std_in_grpo: bool = True,
+    double_normalize: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     response_length = token_level_rewards.shape[-1]
     scores = token_level_rewards.sum(dim=-1)
@@ -74,7 +75,9 @@ def compute_grpo_outcome_advantage(
                 scores[i] = scores[i] - id2mean[index[i]]
 
         scores = scores.unsqueeze(-1).tile([1, response_length]) * response_mask
-        scores = _masked_whiten(scores, response_mask) * response_mask
+        if double_normalize:
+            # Second, batch-global advantage whitening on top of group normalization.
+            scores = _masked_whiten(scores, response_mask) * response_mask
 
     return scores, scores
 
@@ -92,6 +95,7 @@ def _masked_whiten(values: torch.Tensor, mask: torch.Tensor, eps: float = 1e-8) 
 def compute_trajectory_grpo_advantage(
     data,
     norm_adv_by_std_in_grpo: bool = True,
+    double_normalize: bool = True,
 ) -> DataProto:
     advantages, returns = compute_grpo_outcome_advantage(
         token_level_rewards=data.batch["token_level_rewards"],
@@ -99,6 +103,7 @@ def compute_trajectory_grpo_advantage(
         index=data.non_tensor_batch["uid"],
         traj_index=data.non_tensor_batch["traj_uid"],
         norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+        double_normalize=double_normalize,
     )
     data.batch["advantages"] = advantages
     data.batch["returns"] = returns


### PR DESCRIPTION
## Summary
`compute_grpo_outcome_advantage` applies a second, batch-global `masked_whiten`
on top of the per-group GRPO normalization. That extra whitening is a
REINFORCE++-baseline-style tail, not part of standard GRPO, and it couples
advantages across the batch. This PR makes it configurable, defaulting to the
current behavior so existing runs are unaffected.

## Changes
- `reskill/verl_integration/algorithms.py`: add a `double_normalize` flag to
  `compute_grpo_outcome_advantage` / `compute_trajectory_grpo_advantage`; the
  final `masked_whiten` runs only when enabled.
- `reskill/reskill_trainer.py`: read `algorithm.grpo_double_normalize`
  (default `True`) and pass it through.
- `configs/base.yaml`: document `grpo_double_normalize` and the sibling
  `norm_adv_by_std_in_grpo`.

## Behavior
- `grpo_double_normalize: true` (default) — unchanged; reproduces existing results.
- `grpo_double_normalize: false` — standard group-norm-only GRPO.
