### PR TITLE
Declare optional dependencies for the anthropic and openai skill LLM backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Validated stack pins are recorded under `requirements/`.
 The current benchmark extras are `alfworld`, `search`, and `scienceworld`.
 Additional environment support will be added over time.
 
+Skill creation calls out to an LLM, selected by
+`env.trigger_skills.skill_llm.backend`. The default (`bedrock`) works out of the
+box via `boto3`; the other backends need their matching extra:
+
+| `skill_llm.backend` | Install |
+|---|---|
+| `bedrock` (default) | included |
+| `anthropic` | `pip install -e ".[anthropic]"` |
+| `openai` | `pip install -e ".[openai]"` |
+
 ## 🚀 Usage
 
 Prepare data for an environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ alfworld = ["alfworld>=0.4.2", "gymnasium>=1.3.0", "pyyaml>=6.0.0", "textworld[p
 search = ["gym>=0.26.0", "requests>=2.31.0"]
 scienceworld = ["gymnasium>=0.29.0", "scienceworld>=1.1.0"]
 vllm = ["vllm>=0.8.5"]
+# Skill-creation LLM backends, named to match
+# `env.trigger_skills.skill_llm.backend` in configs/base.yaml. The default
+# backend (`bedrock`) uses boto3, which is already a core dependency; the other
+# two each need their own SDK.
+anthropic = ["anthropic>=0.40.0"]
+openai = ["openai>=1.0.0"]
 benchmarks = [
     "alfworld>=0.4.2",
     "gym>=0.26.0",

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -25,3 +25,17 @@ pip install -e ".[search,vllm]" \
   -c requirements/constraints-search-vllm-cu124.txt \
   --extra-index-url https://download.pytorch.org/whl/cu124
 ```
+
+## Skill-creation LLM
+
+The skill-creation stages call an LLM chosen by
+`env.trigger_skills.skill_llm.backend`. The default `bedrock` backend uses
+`boto3` and needs no extra. The `anthropic` and `openai` backends each require
+their own SDK, available as the extras of the same name:
+
+```bash
+pip install -e ".[alfworld,vllm,anthropic]"
+```
+
+These SDKs are not covered by the CUDA constraints files, since they are pure
+API clients with no bearing on the validated training stack.


### PR DESCRIPTION
## Problem

`create_llm_client` in `reskill/utils/llm_client.py` documents and dispatches three `skill_llm.backend` values, but only one of them is installable from our own package metadata:

| `skill_llm.backend` | SDK imported | Declared in `pyproject.toml`? |
|---|---|---|
| `bedrock` (default) | `boto3` | yes, core dependency |
| `openai` | `openai` | **no** |
| `anthropic` | `anthropic` | **no** |

Both SDKs are imported lazily inside the client constructors (`llm_client.py:180`, `llm_client.py:232`), so the failure surfaces at skill-evolution time rather than at import — a run configured with `backend: openai` gets through startup and then raises `ImportError` the first time the skill creator fires.

## Change

- Add `anthropic` and `openai` extras, named to match the `skill_llm.backend` values they enable, so the mapping from config to install command is one-to-one.
- Document the mapping in `README.md` (installation section) and `requirements/README.md`.

No code changes; the default `bedrock` path is unaffected.

## Notes

- The version floors are deliberately conservative. `openai>=1.0.0` is the principled one — `OpenAIClient` uses the `OpenAI` client class and `chat.completions.create`, which is the 1.x API. `anthropic>=0.40.0` is looser than strictly necessary: the client only needs the Messages API and `usage.input_tokens`, both of which long predate 0.40. Happy to lower it.
- These SDKs are intentionally left out of the `constraints-*-cu124.txt` files — they are pure API clients and have no bearing on the validated CUDA training stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)